### PR TITLE
Add animated count-up effect to stats section

### DIFF
--- a/index.html
+++ b/index.html
@@ -54,6 +54,7 @@
     localStorage.setItem('theme', isDark ? 'dark' : 'light');
     toggleBtn.textContent = isDark ? '☀️' : '🌙';
   });
+  
 </script>
 
 
@@ -140,14 +141,34 @@
 		</div>
 	</div>
 	<div class="extra fade-in">
-		<p>We're increasing this data every year</p>
-		<div class="smbox fade-in">
-		<span><center><div class="data fade-in">154</div><div class="det">Active Learners</div></center></span>
-		<span><center><div class="data fade-in">62</div><div class="det">Total Courses</div></center></span>
-		<span><center><div class="data fade-in">56</div><div class="det">Milestones Achieved</div></center></span>
-		<span><center><div class="data fade-in">27</div><div class="det">Total Projects</div></center></span>
-		</div>
-	</div>
+  <p>We're increasing this data every year</p>
+  <div class="smbox fade-in">
+    <span>
+      <center>
+        <div class="data fade-in" data-target="154">0</div>
+        <div class="det">Active Learners</div>
+      </center>
+    </span>
+    <span>
+      <center>
+        <div class="data fade-in" data-target="62">0</div>
+        <div class="det">Total Courses</div>
+      </center>
+    </span>
+    <span>
+      <center>
+        <div class="data fade-in" data-target="56">0</div>
+        <div class="det">Milestones Achieved</div>
+      </center>
+    </span>
+    <span>
+      <center>
+        <div class="data fade-in" data-target="27">0</div>
+        <div class="det">Total Projects</div>
+      </center>
+    </span>
+  </div>
+</div>
 
 
 <!-- TEAM -->

--- a/script.js
+++ b/script.js
@@ -200,4 +200,43 @@ toTopBtn.addEventListener("click", () => {
     behavior: "smooth"
   });
 });
+  function animateCounters() {
+    const counters = document.querySelectorAll(".data");
 
+    counters.forEach(counter => {
+      const target = +counter.getAttribute("data-target");
+      let count = 0;
+      const duration = 2000; // animation duration in ms
+      const startTime = performance.now();
+
+      function updateCounter(currentTime) {
+        const elapsed = currentTime - startTime;
+        // Easing: easeOutCubic
+        const progress = Math.min(elapsed / duration, 1);
+        const easedProgress = 1 - Math.pow(1 - progress, 3);
+
+        count = Math.floor(target * easedProgress);
+        counter.innerText = count;
+
+        if (progress < 1) {
+          requestAnimationFrame(updateCounter);
+        } else {
+          counter.innerText = target; // Ensure exact target at the end
+        }
+      }
+
+      requestAnimationFrame(updateCounter);
+    });
+  }
+
+  // Trigger animation when in viewport
+  const observer = new IntersectionObserver(entries => {
+    entries.forEach(entry => {
+      if (entry.isIntersecting) {
+        animateCounters();
+        observer.disconnect(); // Run only once
+      }
+    });
+  });
+
+  observer.observe(document.querySelector(".extra"));


### PR DESCRIPTION
This PR introduces an animated count-up effect to the statistics section inside .extra.
Fixes: #12 
-Replaced static numbers with data-target attributes.
-Implemented smooth count-up using requestAnimationFrame.
-Added easing (easeOutCubic) for a more natural animation.
-Triggered animation on scroll into viewport with IntersectionObserver.
Changes Made
-Updated HTML to use data-target for stats.
-Added JavaScript logic for animated count-up.
-Ensured animation only runs when the section comes into view.
-Final number always matches the target exactly.
Before
-Stats were static numbers with no animation.
After
-Stats now animate smoothly from 0 → target.
-Easing effect makes animation look professional.
-Works reliably for both large and small numbers.
[count-up.webm](https://github.com/user-attachments/assets/7e1400de-7100-4253-8174-54ba4648f2f1)
