### PR TITLE
Fix: Corrects marquee background and layering in dark mode

### DIFF
--- a/style.css
+++ b/style.css
@@ -1180,8 +1180,8 @@ body.dark-mode .feed #csubmit {
 }
 /* Dark mode for marquee text */
 body.dark-mode .marqu {
-  color: #f3f4f6;
-  background-color: rgba(31, 41, 55, 0.8);
+    color: rgb(243, 244, 246);
+    background-color: transparent; /* This is the fix */
 }
 
 
@@ -1377,4 +1377,10 @@ body.dark-mode footer input::placeholder {
 #toTopBtn:hover {
   background-color: #555;
   transform: scale(1.1);
+}
+/* Fix for marquee banner layering and spacing issue */
+marquee {
+	position: relative;
+	z-index: 999;
+	padding-top: 50px; 
 }


### PR DESCRIPTION
Closes #21 

This PR fixes a visual bug where the scrolling marquee banner was being overlapped by other elements in dark mode.

**Changes:**
- Added a high `z-index` to the `<marquee>` element to ensure it's on the top layer.
- Corrected a spacing issue by replacing `margin-top` in the HTML with `padding-top` in the CSS.
- Removed a semi-transparent background from the inner text `div` in dark mode to ensure a consistent banner color.